### PR TITLE
Adds compatibility with Kirby 3.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
   "name": "texnixe/k3-filesdisplay-section",
-  "description": "Kirby 3 plugin to any file in a section.",
+  "description": "Kirby 3 plugin to display any file in a section.",
   "type": "kirby-plugin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "authors": [
     {
       "name": "Sonja Broda",

--- a/src/FilesDisplaySection.php
+++ b/src/FilesDisplaySection.php
@@ -2,7 +2,6 @@
 
 use Kirby\Exception\InvalidArgumentException;
 use Kirby\Toolkit\Str;
-use Kirby\Toolkit\Query;
 use Kirby\Cms\Section;
 
 
@@ -16,21 +15,26 @@ return array_replace_recursive($base, [
     'props' => [
         'sortable' => function (bool $sortable = true) {
             return false;
-        },   
+        },
         'query' => function(string $query = 'page.files') {
             return $query;
         }
     ],
     'computed' => [
         'files' => function () {
-
-            $q = new Query($this->query, [
+            $context = [
                 'site' => site(),
                 'page' => $this->model(),
                 'pages' => site()->files()
-            ]);
+            ];
+            if (class_exists('Kirby\\Query\\Query')) {
+                $q = new Kirby\Query\Query($this->query);
+                $files = $q->resolve($context);
+            } else {
+                $q = new Kirby\Toolkit\Query($this->query, $context);
+                $files = $q->result();
+            }
 
-            $files = $q->result();
 
             if(is_a($files, 'Kirby\\Cms\\Files')) {
                 // sort
@@ -39,17 +43,17 @@ return array_replace_recursive($base, [
                 } elseif ($this->sortable === true) {
                     $files = $files->sortBy('sort', 'asc');
                 }
-                
+
                 // pagination
                 $files = $files->paginate([
                     'page'  => $this->page,
                     'limit' => $this->limit
                 ]);
-            
+
                 return $files;
             } else {
                 throw new InvalidArgumentException(
-                    'Invalid query result - Result must be of type Kirby\\Cms\\Files, ' 
+                    'Invalid query result - Result must be of type Kirby\\Cms\\Files, '
                     . ($files === NULL ? 'NULL' : get_class($files))
                     . ' given.'
                 );


### PR DESCRIPTION
`Toolkit\Query` will be deprecated in Kirby 3.9, see https://github.com/getkirby/kirby/releases/tag/3.9.0-rc.1
Compare to https://github.com/rasteiner/k3-pagesdisplay-section/commit/094eb8091f6fb99116c378884efa434ecf3dba46